### PR TITLE
Fix broken build (due to libmseed breaking ABI in v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-target/
+/target/
 **/*.rs.bk
-Cargo.lock
+/Cargo.lock
+/src/libmseed

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use git2::Repository;
 
 const REPO_URL: &str = "https://github.com/iris-edu/libmseed";
 const BUILD_DIR: &str = "src/libmseed";
-const GIT_REF: &str = "refs/heads/2.x"; // libmseed v3 broke the ABI
+const GIT_REF: &str = "refs/remotes/origin/2.x"; // libmseed v3 broke the ABI
 
 fn main() {
     let repo = match Repository::clone(REPO_URL, BUILD_DIR) {

--- a/build.rs
+++ b/build.rs
@@ -5,25 +5,26 @@ use std::env;
 use std::process::Command;
 use git2::Repository;
 
+const REPO_URL: &str = "https://github.com/iris-edu/libmseed";
+const BUILD_DIR: &str = "src/libmseed";
+const GIT_REF: &str = "refs/heads/2.x"; // libmseed v3 broke the ABI
 
 fn main() {
-    let url = "https://github.com/iris-edu/libmseed";
-    match Repository::clone(url, "src/libmseed") {
-        Ok(_repo) => {},
-        Err(e) => {
-            match e.code() {
-                git2::ErrorCode::Exists => {
-                    println!("directory exists");
-                },
-                _ => panic!("Failed to update/clone repo: {}", e),
-            }
+    let repo = match Repository::clone(REPO_URL, BUILD_DIR) {
+        Ok(_repo) => _repo,
+        Err(e) => match e.code() {
+            git2::ErrorCode::Exists =>
+                Repository::open(BUILD_DIR)
+                    .expect("Failed to open existing repo"),
+            _ => panic!("Failed to update/clone repo: {}", e),
         }
     };
+    let branch = repo.revparse_single(GIT_REF).unwrap();
+    repo.reset(&branch, git2::ResetType::Hard, None).unwrap();
 
-    let dir = "src/libmseed";
-    let path = std::fs::canonicalize(dir).unwrap();
-    let _ok = env::set_current_dir(&path).is_ok();
-    let _output = Command::new("make").output().expect("make failed");
+    let path = std::fs::canonicalize(BUILD_DIR).unwrap();
+    env::set_current_dir(&path).unwrap();
+    Command::new("make").output().expect("make failed");
 
     println!("cargo:rustc-link-search={}", path.to_str().unwrap());
     println!("cargo:rustc-link-lib={}", "mseed");


### PR DESCRIPTION
The HEAD of https://github.com/iris-edu/libmseed now points to the new libmseed version 3, which has changed the ABI from version 2 (which is what miniseed-rs is clearly expecting to link with). This PR modifies `build.rs` to explicitly check out the libmseed branch `2.x`, allowing linking to succeed.