### PR TITLE
read.rs: write output to tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4"
 glob   = "0.2"
 libc   = "0.2"
 num    = "0.1"
+tempfile = "3.2.0"
 
 [build-dependencies]
 git2 = "0.13"

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,7 +1,9 @@
 extern crate glob;
 extern crate miniseed;
+extern crate tempfile;
 
 use miniseed::{ms_input, ms_output, ms_record};
+use tempfile::tempdir;
 
 #[test]
 fn read() {
@@ -25,9 +27,13 @@ fn read_multiple() {
         println!("{}", m);
     }
 
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("multiple_out.seed");
+
     // Sequence Number is incorrect, but everything else is "ok"
-    let mut out = ms_output::open("tests/multiple_out.seed").unwrap();
+    let mut out = ms_output::open(file_path).unwrap();
     for m in &ms {
         out.write(m);
     }
+    dir.close().unwrap();
 }


### PR DESCRIPTION
Keeps `git status` clean.

This will probably collide with #5 